### PR TITLE
Improve chat layout and colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,20 @@
     <style>
         body {
             font-family: 'Roboto', sans-serif;
+            background-color: #343541; /* Color base de ChatGPT */
+            color: #e5e7eb; /* texto claro */
+        }
+        .chat-container {
+            background-color: #444654; /* contenedor similar a ChatGPT */
+        }
+        .header {
+            background-color: #202123; /* barra superior estilo ChatGPT */
+        }
+        .user-message {
+            background-color: #343541; /* burbuja del usuario */
+        }
+        .bot-message {
+            background-color: #444654; /* burbuja del bot */
         }
         /* Estilos personalizados para la barra de desplazamiento tipo WhatsApp */
         .chat-messages::-webkit-scrollbar {
@@ -32,31 +46,26 @@
         }
     </style>
 </head>
-<body class="bg-gray-900 text-gray-100 flex items-center justify-center min-h-screen">
+<body class="bg-[#343541] text-gray-100 flex items-center justify-center min-h-screen">
 
-    <div class="flex flex-col w-full max-w-md bg-gray-800 rounded-lg shadow-lg overflow-hidden h-[90vh]">
-        <div class="bg-gray-700 p-4 flex items-center justify-between">
+    <div class="flex flex-col w-full max-w-md chat-container rounded-lg shadow-lg overflow-hidden h-[90vh]">
+        <div class="header p-4 flex items-center justify-between">
             <div class="flex items-center">
-                <img src="https://via.placeholder.com/40" alt="Gatito Sentimental" class="rounded-full mr-3 border-2 border-pink-400">
+                <img src="https://via.placeholder.com/40" alt="Gatito Sentimental" class="rounded-full mr-3 border-2 border-green-400">
                 <h1 class="text-xl font-semibold">Gatito Sentimental</h1>
             </div>
             </div>
 
         <div id="chat-messages" class="flex-1 p-4 overflow-y-auto chat-messages">
-            <div class="flex justify-start mb-2">
-                <div class="bg-gray-700 text-gray-100 p-3 rounded-lg max-w-[80%] break-words shadow">
-                    ¡Hola! Soy Gatito Sentimental. Estoy aquí para escucharte y ofrecerte un poco de apoyo. ¿Cómo te sientes hoy?
-                </div>
-            </div>
         </div>
 
         <div class="bg-gray-700 p-4 flex items-center border-t border-gray-600">
             <textarea id="message-input"
-                      class="flex-1 resize-none bg-gray-600 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-pink-500 placeholder-gray-400"
+                      class="flex-1 resize-none bg-gray-600 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-green-500 placeholder-gray-400"
                       rows="1"
                       placeholder="Escribe tu mensaje..."></textarea>
             <button id="send-button"
-                    class="bg-pink-600 hover:bg-pink-700 text-white rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-pink-500">
+                    class="bg-green-600 hover:bg-green-700 text-white rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-green-500">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transform rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                 </svg>

--- a/main.js
+++ b/main.js
@@ -23,14 +23,14 @@ function addMessageToUI(text, sender = 'user') {
     if (sender === 'user') {
         messageDiv.classList.add('justify-end');
         messageDiv.innerHTML = `
-            <div class="bg-blue-600 text-white p-3 rounded-lg max-w-[80%] break-words shadow">
+            <div class="user-message text-gray-100 p-3 rounded-lg max-w-[80%] break-words shadow">
                 ${text}
             </div>
         `;
     } else { // sender === 'bot'
         messageDiv.classList.add('justify-start');
         messageDiv.innerHTML = `
-            <div class="bg-gray-700 text-gray-100 p-3 rounded-lg max-w-[80%] break-words shadow">
+            <div class="bot-message text-gray-100 p-3 rounded-lg max-w-[80%] break-words shadow">
                 ${text}
             </div>
         `;


### PR DESCRIPTION
## Summary
- tweak CSS to use ChatGPT-like color scheme
- use user and bot message bubbles
- remove duplicate greeting message
- adjust accent color to green

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_687304b80a14832698af292139e01d24