### PR TITLE
Actualizar chat con Puter.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,20 +9,17 @@
     <style>
         body {
             font-family: 'Roboto', sans-serif;
-            background-color: #343541; /* Color base de ChatGPT */
+            background-color: #000; /* fondo principal negro */
             color: #e5e7eb; /* texto claro */
         }
         .chat-container {
-            background-color: #444654; /* contenedor similar a ChatGPT */
-        }
-        .header {
-            background-color: #202123; /* barra superior estilo ChatGPT */
+            background-color: #333; /* contenedor gris */
         }
         .user-message {
-            background-color: #343541; /* burbuja del usuario */
+            background-color: #444; /* burbuja del usuario */
         }
         .bot-message {
-            background-color: #444654; /* burbuja del bot */
+            background-color: #555; /* burbuja del bot */
         }
         /* Estilos personalizados para la barra de desplazamiento tipo WhatsApp */
         .chat-messages::-webkit-scrollbar {
@@ -46,26 +43,22 @@
         }
     </style>
 </head>
-<body class="bg-[#343541] text-gray-100 flex items-center justify-center min-h-screen">
+<body class="bg-black text-gray-100 flex items-center justify-center min-h-screen">
+    <button id="new-chat" class="absolute top-4 left-4 bg-white text-black px-3 py-1 rounded">Nuevo chat</button>
+    <button id="login-button" class="absolute top-4 right-4 bg-white text-black px-3 py-1 rounded">Iniciar sesión</button>
 
     <div class="flex flex-col w-full max-w-md chat-container rounded-lg shadow-lg overflow-hidden h-[90vh]">
-        <div class="header p-4 flex items-center justify-between">
-            <div class="flex items-center">
-                <img src="https://via.placeholder.com/40" alt="Gatito Sentimental" class="rounded-full mr-3 border-2 border-green-400">
-                <h1 class="text-xl font-semibold">Gatito Sentimental</h1>
-            </div>
-            </div>
 
         <div id="chat-messages" class="flex-1 p-4 overflow-y-auto chat-messages">
         </div>
 
-        <div class="bg-gray-700 p-4 flex items-center border-t border-gray-600">
+        <div class="bg-gray-800 p-4 flex items-center border-t border-gray-700">
             <textarea id="message-input"
-                      class="flex-1 resize-none bg-gray-600 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-green-500 placeholder-gray-400"
+                      class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
                       rows="1"
                       placeholder="Escribe tu mensaje..."></textarea>
             <button id="send-button"
-                    class="bg-green-600 hover:bg-green-700 text-white rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-green-500">
+                    class="bg-white text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transform rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                 </svg>

--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@
 const chatMessages = document.getElementById('chat-messages');
 const messageInput = document.getElementById('message-input');
 const sendButton = document.getElementById('send-button');
+const newChatButton = document.getElementById('new-chat');
+const loginButton = document.getElementById('login-button');
 
 // Historial de la conversación para mantener el contexto
 // Incluimos un mensaje inicial del sistema para definir la personalidad de Gatito Sentimental
@@ -14,6 +16,46 @@ let history = [
     // Aunque no está en el historial 'real' del modelo, inicia la conversación en la UI.
     // La primera interacción del usuario con Gatito Sentimental definirá el primer 'user' en history.
 ];
+
+// Guardar el historial en la base de datos
+async function saveHistory() {
+    try {
+        await puter.kv.set('chatHistory', JSON.stringify(history));
+        console.log('Historial guardado exitosamente');
+    } catch (e) {
+        console.error('Error al guardar historial', e);
+    }
+}
+
+// Cargar historial almacenado
+async function loadHistory() {
+    try {
+        const data = await puter.kv.get('chatHistory');
+        if (data) {
+            history = JSON.parse(data);
+            for (const msg of history) {
+                if (msg.role === 'user') addMessageToUI(msg.content, 'user');
+                if (msg.role === 'assistant') addMessageToUI(msg.content, 'bot');
+            }
+        }
+    } catch (e) {
+        console.error('Error al leer historial', e);
+    }
+}
+
+// Comprobar estado de inicio de sesión y mostrar/ocultar botón
+async function updateLoginState() {
+    try {
+        const user = await (puter.auth.user?.());
+        if (user) {
+            loginButton.style.display = 'none';
+        } else {
+            loginButton.style.display = 'block';
+        }
+    } catch {
+        loginButton.style.display = 'block';
+    }
+}
 
 // Función para añadir un mensaje al chat en la UI
 function addMessageToUI(text, sender = 'user') {
@@ -40,10 +82,7 @@ function addMessageToUI(text, sender = 'user') {
     chatMessages.scrollTop = chatMessages.scrollHeight;
 }
 
-// Mostrar el mensaje de bienvenida inicial de Gatito Sentimental al cargar la página
-document.addEventListener('DOMContentLoaded', () => {
-    addMessageToUI('¡Hola! Soy Gatito Sentimental. Estoy aquí para escucharte y ofrecerte un poco de apoyo. ¿Cómo te sientes hoy?', 'bot');
-});
+
 
 
 // Función para enviar el mensaje y obtener respuesta de Gemini
@@ -56,6 +95,7 @@ async function sendMessage() {
 
     // Añadir el mensaje del usuario al historial para el contexto de la IA
     history.push({ role: "user", content: userMessage });
+    await saveHistory();
 
     // Deshabilitar input y botón mientras se espera la respuesta
     messageInput.disabled = true;
@@ -84,7 +124,7 @@ async function sendMessage() {
                     const messageContainer = document.createElement('div');
                     messageContainer.classList.add('flex', 'mb-2', 'justify-start');
                     botMessageDiv = document.createElement('div');
-                    botMessageDiv.classList.add('bg-gray-700', 'text-gray-100', 'p-3', 'rounded-lg', 'max-w-[80%]', 'break-words', 'shadow');
+                    botMessageDiv.classList.add('bot-message', 'text-gray-100', 'p-3', 'rounded-lg', 'max-w-[80%]', 'break-words', 'shadow');
                     messageContainer.appendChild(botMessageDiv);
                     chatMessages.appendChild(messageContainer);
                 }
@@ -98,6 +138,7 @@ async function sendMessage() {
 
         // Una vez que el streaming ha terminado, añadir la respuesta completa del asistente al historial
         history.push({ role: "assistant", content: assistantReply });
+        await saveHistory();
 
     } catch (error) {
         console.error("Error al llamar a la API de Gemini:", error);
@@ -134,3 +175,19 @@ messageInput.addEventListener('keypress', (e) => {
 
 // Ajustar la altura inicial del textarea (en caso de contenido preexistente)
 messageInput.style.height = (messageInput.scrollHeight) + 'px';
+
+newChatButton.addEventListener('click', async () => {
+    history = history.filter(m => m.role === 'system');
+    chatMessages.innerHTML = '';
+    await puter.kv.del('chatHistory');
+});
+
+loginButton.addEventListener('click', async () => {
+    await puter.auth.login();
+    updateLoginState();
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadHistory();
+    updateLoginState();
+});


### PR DESCRIPTION
## Summary
- simplificar el estilo con fondo negro y contenedores grises
- quitar el mensaje inicial y el encabezado
- agregar botones de "Nuevo chat" e "Iniciar sesión"
- guardar el historial de mensajes usando Puter.kv
- cargar historial y gestionar sesión

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6873097f00f08326a3e0702f897c2f61