### PR TITLE
Mejoras en UI y manejo de sesión

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -2,7 +2,8 @@ import { loginButton } from './ui.js';
 
 export async function updateLoginState() {
     try {
-        const user = await (puter.auth.user?.());
+        const possibleFn = puter?.auth?.user;
+        const user = typeof possibleFn === 'function' ? await possibleFn() : possibleFn;
         if (user) {
             loginButton.style.display = 'none';
         } else {

--- a/chat.js
+++ b/chat.js
@@ -53,7 +53,7 @@ export async function sendMessage() {
         await saveHistory();
 
     } catch (error) {
-        console.error('Error al llamar a la API de Gemini:', error);
+        console.error('Error al llamar a la IA:', error);
         addMessageToUI('Lo siento, hubo un error al obtener la respuesta. Por favor, inténtalo de nuevo más tarde.', 'bot');
     } finally {
         messageInput.disabled = false;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <style>
         body {
             font-family: 'Roboto', sans-serif;
-            background-color: #000; /* fondo principal negro */
+            background-color: #333; /* fondo principal ahora gris */
             color: #e5e7eb; /* texto claro */
         }
         .chat-container {
@@ -43,11 +43,11 @@
         }
     </style>
 </head>
-<body class="bg-black text-gray-100 flex items-center justify-center min-h-screen">
+<body class="bg-gray-800 text-gray-100 min-h-screen">
     <button id="new-chat" class="absolute top-4 left-4 bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Nuevo chat</button>
     <button id="login-button" class="absolute top-4 right-4 bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Iniciar sesión</button>
 
-    <div class="flex flex-col w-full max-w-md chat-container rounded-lg shadow-lg overflow-hidden h-[90vh]">
+    <div class="flex flex-col w-full h-screen chat-container overflow-hidden">
 
         <div id="intro-screen" class="flex-1 flex flex-col items-center justify-center text-center p-4 hidden">
             <h1 class="text-2xl font-bold mb-4">¿En qué puedo ayudarte?</h1>


### PR DESCRIPTION
## Summary
- ajustar estilos para que el chat utilice todo el fondo gris y el campo de texto quede abajo
- ocultar el botón de login si el usuario ya inició sesión
- mensaje de error genérico al fallar la llamada a la IA

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687774484538832687f04b23f4236471