### PR TITLE
Fix UI overlap and improve text input

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,31 +44,33 @@
     </style>
 </head>
 <body class="bg-gray-800 text-gray-100 min-h-screen">
-    <button id="new-chat" class="absolute top-4 left-4 bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Nuevo chat</button>
-    <button id="login-button" class="absolute top-4 right-4 bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Iniciar sesión</button>
-
     <div class="flex flex-col w-full h-screen chat-container overflow-hidden">
+        <div class="flex justify-between p-4">
+            <button id="new-chat" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Nuevo chat</button>
+            <button id="login-button" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Iniciar sesión</button>
+        </div>
 
         <div id="intro-screen" class="flex-1 flex flex-col items-center justify-center text-center p-4 hidden">
             <h1 class="text-2xl font-bold mb-4">¿En qué puedo ayudarte?</h1>
             <div id="suggestions" class="flex flex-col items-center gap-3 w-full"></div>
         </div>
 
-        <div id="chat-messages" class="flex-1 p-4 overflow-y-auto chat-messages hidden">
+        <div id="chat-messages" class="flex-1 p-4 pb-32 overflow-y-auto chat-messages hidden">
         </div>
 
-        <div class="bg-gray-800 p-4 flex items-center border-t border-gray-700">
-            <textarea id="message-input"
-                      class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
-                      rows="1"
-                      placeholder="Escribe tu mensaje..."></textarea>
-            <button id="send-button"
-                    class="bg-white text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transform rotate-45" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-                </svg>
-            </button>
-        </div>
+    </div>
+
+    <div id="chat-input" class="bg-gray-800 p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
+        <textarea id="message-input"
+                  class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
+                  rows="1"
+                  placeholder="Escribe tu mensaje..."></textarea>
+        <button id="send-button"
+                class="bg-white text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transform rotate-45" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+            </svg>
+        </button>
     </div>
 
     <script src="https://js.puter.com/v2/"></script>


### PR DESCRIPTION
## Summary
- keep login and new chat buttons in a header so they don't cover messages
- make message input fixed to the bottom
- leave padding on chat area so input is always visible

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68777660143c832685a52ead8a97ade4