### PR TITLE
Add sidebar chat history and dark input

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,5 +1,5 @@
 import { chatMessages, messageInput, sendButton, introScreen } from './ui.js';
-import { history, saveHistory } from './history.js';
+import { history, saveHistory, updateCurrentChatTitle, chatList } from './history.js';
 import { addMessageToUI } from './ui.js';
 
 export async function sendMessage() {
@@ -14,6 +14,9 @@ export async function sendMessage() {
 
     history.push({ role: 'user', content: userMessage });
     await saveHistory();
+    if (chatList.length > 0 && chatList[0].title === 'Nuevo chat') {
+        updateCurrentChatTitle(userMessage.substring(0, 30));
+    }
 
     messageInput.disabled = true;
     sendButton.disabled = true;

--- a/history.js
+++ b/history.js
@@ -1,26 +1,80 @@
-export let history = [
-    {
-        role: "system",
-        content: `Eres Gatito Sentimental, un personaje de TikTok que ofrece apoyo, consejos y recomendaciones sobre superaci\u00f3n, aceptaci\u00f3n y psicolog\u00eda. Eres humilde, emp\u00e1tico, no serio y tu objetivo es ayudar a las personas a sentirse mejor consigo mismas. Responde de manera concisa y amable, como lo har\u00eda Gatito Sentimental. Evita parecer un asistente de IA gen\u00e9rico.`
+export let history = [];
+export let chatList = [];
+export let currentChatId = null;
+
+const systemMessage = {
+    role: "system",
+    content: `Eres Gatito Sentimental, un personaje de TikTok que ofrece apoyo, consejos y recomendaciones sobre superación, aceptación y psicología. Eres humilde, empático, no serio y tu objetivo es ayudar a las personas a sentirse mejor consigo mismas. Responde de manera concisa y amable, como lo haría Gatito Sentimental. Evita parecer un asistente de IA genérico.`
+};
+
+export async function loadChatList() {
+    try {
+        const data = await puter.kv.get('chatList');
+        if (data) chatList = JSON.parse(data);
+    } catch (e) {
+        console.error('Error al leer lista', e);
     }
-];
+}
+
+export async function saveChatList() {
+    try {
+        await puter.kv.set('chatList', JSON.stringify(chatList));
+    } catch (e) {
+        console.error('Error al guardar lista', e);
+    }
+}
+
+export async function createNewChat() {
+    const id = Date.now().toString();
+    currentChatId = id;
+    history = [systemMessage];
+    chatList.unshift({ id, title: 'Nuevo chat' });
+    await saveChatList();
+    await saveHistory();
+    return id;
+}
+
+export async function deleteChat(id) {
+    try {
+        await puter.kv.del(`chatHistory-${id}`);
+        chatList = chatList.filter(c => c.id !== id);
+        await saveChatList();
+        if (currentChatId === id) {
+            await createNewChat();
+        }
+    } catch (e) {
+        console.error('Error al borrar chat', e);
+    }
+}
 
 export async function saveHistory() {
+    if (!currentChatId) return;
     try {
-        await puter.kv.set('chatHistory', JSON.stringify(history));
-        console.log('Historial guardado exitosamente');
+        await puter.kv.set(`chatHistory-${currentChatId}`, JSON.stringify(history));
     } catch (e) {
         console.error('Error al guardar historial', e);
     }
 }
 
-export async function loadHistory() {
+export async function loadHistory(id) {
+    currentChatId = id;
     try {
-        const data = await puter.kv.get('chatHistory');
+        const data = await puter.kv.get(`chatHistory-${id}`);
         if (data) {
             history = JSON.parse(data);
+        } else {
+            history = [systemMessage];
         }
     } catch (e) {
         console.error('Error al leer historial', e);
+        history = [systemMessage];
+    }
+}
+
+export function updateCurrentChatTitle(title) {
+    const chat = chatList.find(c => c.id === currentChatId);
+    if (chat) {
+        chat.title = title;
+        saveChatList();
     }
 }

--- a/index.html
+++ b/index.html
@@ -46,8 +46,11 @@
 <body class="bg-gray-800 text-gray-100 min-h-screen">
     <div class="flex flex-col w-full h-screen chat-container overflow-hidden">
         <div class="flex justify-between p-4">
-            <button id="new-chat" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Nuevo chat</button>
-            <button id="login-button" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium">Iniciar sesión</button>
+            <button id="menu-button" class="text-white focus:outline-none">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+            </button>
         </div>
 
         <div id="intro-screen" class="flex-1 flex flex-col items-center justify-center text-center p-4 hidden">
@@ -60,9 +63,19 @@
 
     </div>
 
+    <div id="sidebar" class="fixed top-0 right-0 w-64 h-full bg-gray-900 text-white transform translate-x-full transition-transform flex flex-col">
+        <div class="p-4 border-b border-gray-700">
+            <button id="sidebar-new-chat" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Nuevo chat</button>
+        </div>
+        <ul id="chat-list" class="flex-1 overflow-y-auto p-4 space-y-2"></ul>
+        <div class="p-4 border-t border-gray-700">
+            <button id="login-button" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Iniciar sesión</button>
+        </div>
+    </div>
+
     <div id="chat-input" class="bg-gray-800 p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
         <textarea id="message-input"
-                  class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
+                  class="flex-1 resize-none bg-black text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
                   rows="1"
                   placeholder="Escribe tu mensaje..."></textarea>
         <button id="send-button"

--- a/ui.js
+++ b/ui.js
@@ -1,8 +1,11 @@
 export const chatMessages = document.getElementById('chat-messages');
 export const messageInput = document.getElementById('message-input');
 export const sendButton = document.getElementById('send-button');
-export const newChatButton = document.getElementById('new-chat');
+export const menuButton = document.getElementById('menu-button');
+export const sidebar = document.getElementById('sidebar');
+export const sidebarNewChat = document.getElementById('sidebar-new-chat');
 export const loginButton = document.getElementById('login-button');
+export const chatList = document.getElementById('chat-list');
 export const introScreen = document.getElementById('intro-screen');
 export const suggestionsContainer = document.getElementById('suggestions');
 


### PR DESCRIPTION
## Summary
- replace buttons with a hamburger menu
- add a right sidebar listing chats with options to create or delete
- implement multi-chat storage logic
- update chat code to rename chats automatically
- color the message input black

## Testing
- `node --check main.js`
- `node --check chat.js`
- `node --check history.js`


------
https://chatgpt.com/codex/tasks/task_e_68777b2a03148326aeb68f381350669f