### PR TITLE
Add blur and message menu features

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Chat de Gatito Sentimental</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="foto_perfil.png">
     <style>
         body {
             font-family: 'Roboto', sans-serif;
@@ -71,7 +72,7 @@
         <ul id="chat-list" class="flex-1 overflow-y-auto p-4 space-y-2"></ul>
     </div>
 
-    <div id="overlay" class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm hidden z-10"></div>
+    <div id="overlay" class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur hidden z-10"></div>
 
     <div id="chat-input" class="bg-gray-800 p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
         <textarea id="message-input"
@@ -87,6 +88,7 @@
     </div>
 
     <script src="https://js.puter.com/v2/"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use profile image as favicon
- apply blur outside of sidebar
- render markdown using marked
- add avatars to bot messages
- implement message context menu with copy/edit/regenerate
- expose regenerate helper

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68788f54b6248326be0304a754bd3271