### PR TITLE
Improve mobile UI interactions

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -50,7 +50,9 @@ export async function sendMessage(forcedText) {
                     const img = document.createElement('img');
                     img.src = 'foto_perfil.png';
                     img.alt = 'perfil';
-                    img.className = 'w-8 h-8 rounded-full absolute -top-3 -left-3';
+                    img.className = 'w-8 h-8 rounded-full absolute';
+                    img.style.left = '-9px';
+                    img.style.top = '-9px';
                     botMessageDiv.appendChild(img);
                     textContainer = document.createElement('div');
                     botMessageDiv.appendChild(textContainer);

--- a/main.js
+++ b/main.js
@@ -90,16 +90,22 @@ function renderChatList() {
 
 sendButton.addEventListener('click', sendMessage);
 
+function resizeInput() {
+    messageInput.style.height = 'auto';
+    messageInput.style.height = messageInput.scrollHeight + 'px';
+}
+
 messageInput.addEventListener('keypress', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         sendMessage();
     }
-    messageInput.style.height = 'auto';
-    messageInput.style.height = messageInput.scrollHeight + 'px';
 });
 
-messageInput.style.height = messageInput.scrollHeight + 'px';
+messageInput.addEventListener('input', resizeInput);
+messageInput.addEventListener('paste', () => setTimeout(resizeInput));
+
+resizeInput();
 
 menuButton.addEventListener('click', () => {
     const isOpen = !sidebar.classList.toggle('translate-x-full');
@@ -108,6 +114,8 @@ menuButton.addEventListener('click', () => {
 
 overlay.addEventListener('click', () => {
     sidebar.classList.add('translate-x-full');
+    const menu = document.getElementById('message-menu');
+    if (menu) menu.remove();
     overlay.classList.add('hidden');
 });
 

--- a/ui.js
+++ b/ui.js
@@ -27,7 +27,9 @@ export function addMessageToUI(text, sender = 'user') {
         const img = document.createElement('img');
         img.src = 'foto_perfil.png';
         img.alt = 'perfil';
-        img.className = 'w-8 h-8 rounded-full absolute -top-3 -left-3';
+        img.className = 'w-8 h-8 rounded-full absolute';
+        img.style.left = '-9px';
+        img.style.top = '-9px';
         bubble.appendChild(img);
         const content = document.createElement('div');
         content.innerHTML = marked.parse(text);
@@ -46,13 +48,22 @@ export function showMessageMenu(event, sender, bubble) {
     event.stopPropagation();
 
     const existing = document.getElementById('message-menu');
-    if (existing) existing.remove();
+    if (existing) {
+        existing.remove();
+        overlay.classList.add('hidden');
+        if (existing.dataset.for === bubble.dataset.message) {
+            return;
+        }
+    }
 
     const menu = document.createElement('div');
     menu.id = 'message-menu';
+    menu.dataset.for = bubble.dataset.message;
     menu.className = 'absolute bg-gray-700 text-white rounded shadow-lg p-2 text-sm space-y-1 z-30';
-    menu.style.top = event.pageY + 'px';
-    menu.style.left = event.pageX + 'px';
+    const rect = bubble.getBoundingClientRect();
+    menu.style.top = rect.bottom + window.scrollY + 'px';
+    menu.style.left = rect.left + window.scrollX + 'px';
+    overlay.classList.remove('hidden');
 
     const copyBtn = document.createElement('button');
     copyBtn.textContent = 'Copiar';
@@ -91,6 +102,7 @@ export function showMessageMenu(event, sender, bubble) {
     const closeMenu = (e) => {
         if (!menu.contains(e.target)) {
             menu.remove();
+            overlay.classList.add('hidden');
             document.removeEventListener('click', closeMenu);
         }
     };


### PR DESCRIPTION
## Summary
- keep profile image aligned in chat bubbles
- keep textarea size in sync when typing or pasting
- close message menu on repeated taps
- open message menu near the bubble and blur the background
- hide menu when tapping overlay

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68789f0134f88326849db6d28711ea06