### PR TITLE
Implement personalization modal and dynamic input

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,11 +47,6 @@
 <body class="bg-gray-800 text-gray-100 min-h-screen">
     <div class="flex flex-col w-full h-screen chat-container overflow-hidden">
         <div class="flex justify-between p-4">
-            <button id="menu-button" class="text-white focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
         </div>
 
         <div id="intro-screen" class="flex-1 flex flex-col items-center justify-center text-center p-4 hidden">
@@ -64,20 +59,42 @@
 
     </div>
 
-    <div id="sidebar" class="fixed top-0 right-0 w-64 h-full bg-black text-white transform translate-x-full transition-transform flex flex-col z-20">
+    <div id="sidebar" class="fixed top-0 right-0 w-64 h-full bg-black text-white transition-transform flex flex-col z-20">
         <div class="p-4 border-b border-gray-700 space-y-4">
             <button id="sidebar-new-chat" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Nuevo chat</button>
             <button id="login-button" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Iniciar sesión</button>
+            <button id="personalize-button" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Personalización</button>
         </div>
         <ul id="chat-list" class="flex-1 overflow-y-auto p-4 space-y-2"></ul>
     </div>
 
     <div id="overlay" class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur hidden z-10"></div>
 
+    <div id="personalization-modal" class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur flex items-center justify-center hidden z-30">
+        <div class="bg-gray-800 p-4 rounded space-y-4 w-11/12 max-w-md">
+            <label class="block text-sm">
+                <span class="text-gray-100">¿Cómo debería llamarte Gatito Sentimental?</span>
+                <input id="personal-name" class="w-full mt-1 p-2 bg-gray-700 rounded" />
+            </label>
+            <label class="block text-sm">
+                <span class="text-gray-100">¿Qué características debería tener Gatito Sentimental?</span>
+                <textarea id="personal-features" rows="3" class="w-full mt-1 p-2 bg-gray-700 rounded resize-none"></textarea>
+            </label>
+            <label class="block text-sm">
+                <span class="text-gray-100">¿Hay algo más que ChatGPT debería saber sobre ti?</span>
+                <textarea id="personal-extra" rows="3" class="w-full mt-1 p-2 bg-gray-700 rounded resize-none"></textarea>
+            </label>
+            <div class="flex justify-end gap-2">
+                <button id="personal-cancel" class="bg-gray-600 px-4 py-2 rounded">Cancelar</button>
+                <button id="personal-save" class="bg-white text-black px-4 py-2 rounded font-medium">Guardar</button>
+            </div>
+        </div>
+    </div>
+
     <div id="chat-input" class="bg-gray-800 p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
         <textarea id="message-input"
                   class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
-                  rows="1"
+                  rows="1" style="max-height:200px;"
                   placeholder="Escribe tu mensaje..."></textarea>
         <button id="send-button"
                 class="bg-white text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">

--- a/ui.js
+++ b/ui.js
@@ -1,10 +1,16 @@
 export const chatMessages = document.getElementById('chat-messages');
 export const messageInput = document.getElementById('message-input');
 export const sendButton = document.getElementById('send-button');
-export const menuButton = document.getElementById('menu-button');
 export const sidebar = document.getElementById('sidebar');
 export const sidebarNewChat = document.getElementById('sidebar-new-chat');
 export const loginButton = document.getElementById('login-button');
+export const personalizeButton = document.getElementById('personalize-button');
+export const personalizationModal = document.getElementById('personalization-modal');
+export const personalName = document.getElementById('personal-name');
+export const personalFeatures = document.getElementById('personal-features');
+export const personalExtra = document.getElementById('personal-extra');
+export const personalSave = document.getElementById('personal-save');
+export const personalCancel = document.getElementById('personal-cancel');
 export const chatList = document.getElementById('chat-list');
 export const introScreen = document.getElementById('intro-screen');
 export const suggestionsContainer = document.getElementById('suggestions');


### PR DESCRIPTION
## Summary
- adjust sidebar to always show and remove menu button
- add personalization modal for customizing the chat bot
- store personalization data with Puter.js and use it in system prompt
- update UI exports for new elements
- allow textarea to grow up to 200px before scrolling

## Testing
- `node -c main.js`
- `node -c history.js`
- `node -c ui.js`


------
https://chatgpt.com/codex/tasks/task_e_687a012ddf30832688987dd4d0e15d79