### PR TITLE
Add persistent user memory

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,5 +1,6 @@
 import { chatMessages, messageInput, sendButton, introScreen, showMessageMenu, addMessageToUI } from './ui.js';
-import { history, saveHistory, updateCurrentChatTitle, chatList } from './history.js';
+import { history, saveHistory, updateCurrentChatTitle, chatList, refreshSystemMessage } from './history.js';
+import { updateMemoryFromMessage, saveMemory } from './memory.js';
 
 export async function sendMessage(forcedText) {
     const userMessage = (forcedText !== undefined ? forcedText : messageInput.value).trim();
@@ -17,6 +18,12 @@ export async function sendMessage(forcedText) {
 
     history.push({ role: 'user', content: userMessage });
     await saveHistory();
+    const memUpdated = updateMemoryFromMessage(userMessage);
+    if (memUpdated) {
+        await saveMemory();
+        refreshSystemMessage();
+        await saveHistory();
+    }
     if (chatList.length > 0 && chatList[0].title === 'Nuevo chat') {
         updateCurrentChatTitle(userMessage.substring(0, 30));
     }

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import { chatMessages, messageInput, sendButton, menuButton, sidebar, sidebarNewChat, customizationButton, customizationModal, customNameInput, customTraitsInput, customExtraInput, customSaveButton, customCancelButton, chatList as chatListUI, introScreen, suggestionsContainer, overlay, addMessageToUI, showMessageMenu } from './ui.js';
-import { history, chatList, loadHistory, loadChatList, createNewChat, deleteChat, updateCurrentChatTitle, loadCustomization, saveCustomization, personalization } from './history.js';
+import { history, chatList, loadHistory, loadChatList, createNewChat, deleteChat, updateCurrentChatTitle, loadCustomization, saveCustomization, personalization, refreshSystemMessage } from './history.js';
+import { loadMemory } from './memory.js';
 import { sendMessage, regenerateResponse } from './chat.js';
 
 const suggestions = [
@@ -161,6 +162,8 @@ customSaveButton.addEventListener('click', async () => {
 
 document.addEventListener('DOMContentLoaded', async () => {
     await loadCustomization();
+    await loadMemory();
+    refreshSystemMessage();
     await loadChatList();
     if (chatList.length === 0) {
         await createNewChat();

--- a/memory.js
+++ b/memory.js
@@ -1,0 +1,48 @@
+export let userMemory = { name: '', age: '', interests: [] };
+
+export async function loadMemory() {
+    try {
+        const data = await puter.kv.get('userMemory');
+        if (data) userMemory = JSON.parse(data);
+    } catch (e) {
+        console.error('Error al cargar memoria', e);
+    }
+}
+
+export async function saveMemory() {
+    try {
+        await puter.kv.set('userMemory', JSON.stringify(userMemory));
+    } catch (e) {
+        console.error('Error al guardar memoria', e);
+    }
+}
+
+export function updateMemoryFromMessage(message) {
+    let updated = false;
+    const nameMatch = message.match(/(?:me llamo|mi nombre es|soy)\s+([\p{L}]+(?:\s+[\p{L}]+)?)/iu);
+    if (nameMatch && !userMemory.name) {
+        userMemory.name = nameMatch[1].trim();
+        updated = true;
+    }
+
+    const ageMatch = message.match(/(\d{1,3})\s*a(?:ñ|n)os?/iu);
+    if (ageMatch && !userMemory.age) {
+        userMemory.age = ageMatch[1];
+        updated = true;
+    }
+
+    const interestMatch = message.match(/(?:me interes(?:a|an)|me gusta(?:n)?|mis intereses son|estoy interesado en)\s+([^.!?]+)/i);
+    if (interestMatch) {
+        const interests = interestMatch[1]
+            .split(/,| y /i)
+            .map(s => s.trim())
+            .filter(Boolean);
+        for (const it of interests) {
+            if (!userMemory.interests.includes(it)) {
+                userMemory.interests.push(it);
+                updated = true;
+            }
+        }
+    }
+    return updated;
+}


### PR DESCRIPTION
## Summary
- store user memory such as name, age and interests
- include that memory in system prompts
- refresh system prompt whenever memory or personalization changes
- update UI initialization and message sending to load/update memory

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687a04f96aa88326911ca6c9cf4ab21f