### PR TITLE
Actualiza temas e iconos

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
     <style>
         body {
             font-family: 'Roboto', sans-serif;
-            background-color: #333; /* fondo principal ahora gris */
+            background-color: #121212; /* fondo principal ahora gris */
             color: #e5e7eb; /* texto claro */
         }
         .chat-container {
-            background-color: #333; /* contenedor gris */
+            background-color: #121212; /* contenedor gris */
         }
         .user-message {
             background-color: #444; /* burbuja del usuario */
@@ -44,7 +44,7 @@
         }
     </style>
 </head>
-<body class="bg-gray-800 text-gray-100 min-h-screen">
+<body class="bg-black text-gray-100 min-h-screen">
     <div class="flex flex-col w-full h-screen chat-container overflow-hidden">
         <div class="flex justify-between p-4">
             <button id="menu-button" class="text-white focus:outline-none">
@@ -64,10 +64,22 @@
 
     </div>
 
-    <div id="sidebar" class="fixed top-0 right-0 w-64 h-full bg-black text-white transform translate-x-full transition-transform flex flex-col z-20">
+    <div id="sidebar" class="fixed top-0 right-0 w-64 h-full bg-[#121212] text-white transform translate-x-full transition-transform flex flex-col z-20">
         <div class="p-4 border-b border-gray-700 space-y-4">
-            <button id="sidebar-new-chat" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Nuevo chat</button>
-            <button id="customization-button" class="bg-white text-black px-4 py-2 rounded shadow hover:bg-gray-200 font-medium w-full">Personalización</button>
+            <button id="sidebar-new-chat" class="flex items-center gap-2 w-full text-[#FAFAFA]">
+                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M3 4h7v14H3zM14 4h7v14h-7z" />
+                    <path d="M12 13l4-4 3 3-4 4z" />
+                </svg>
+                <span>Nuevo chat</span>
+            </button>
+            <button id="customization-button" class="flex items-center gap-2 w-full text-[#FAFAFA]">
+                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M4 20h4l9-9-4-4-9 9v4z" />
+                    <path d="M14 7l3 3" />
+                </svg>
+                <span>Personalización</span>
+            </button>
         </div>
         <ul id="chat-list" class="flex-1 overflow-y-auto p-4 space-y-2"></ul>
     </div>
@@ -75,34 +87,34 @@
     <div id="overlay" class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur hidden z-10"></div>
 
     <div id="customization-modal" class="fixed inset-0 flex items-center justify-center z-30 hidden">
-        <div class="bg-gray-800 text-gray-100 p-6 rounded-lg space-y-4 w-11/12 max-w-md">
+        <div class="bg-[#121212] text-gray-100 p-6 rounded-lg space-y-4 w-11/12 max-w-md">
             <label class="block text-sm">
                 ¿Cómo debería llamarte Gatito Sentimental?
-                <input id="custom-name" type="text" class="mt-1 w-full bg-gray-700 rounded p-2" />
+                <input id="custom-name" type="text" class="mt-1 w-full bg-[#2C2C2E] rounded p-2" />
             </label>
             <label class="block text-sm">
                 ¿Qué características debería tener Gatito Sentimental?
-                <textarea id="custom-traits" rows="2" class="mt-1 w-full bg-gray-700 rounded p-2"></textarea>
+                <textarea id="custom-traits" rows="2" class="mt-1 w-full bg-[#2C2C2E] rounded p-2"></textarea>
             </label>
             <label class="block text-sm">
                 ¿Hay algo más que Gatito Sentimental debería saber sobre ti?
-                <textarea id="custom-extra" rows="2" class="mt-1 w-full bg-gray-700 rounded p-2"></textarea>
+                <textarea id="custom-extra" rows="2" class="mt-1 w-full bg-[#2C2C2E] rounded p-2"></textarea>
             </label>
             <div class="flex justify-end space-x-2">
-                <button id="custom-cancel" class="px-4 py-2 bg-gray-600 rounded">Cancelar</button>
-                <button id="custom-save" class="px-4 py-2 bg-white text-black rounded">Guardar</button>
+                <button id="custom-cancel" class="px-4 py-2 bg-[#FAFAFA] rounded">Cancelar</button>
+                <button id="custom-save" class="px-4 py-2 bg-[#FAFAFA] text-black rounded">Guardar</button>
             </div>
         </div>
     </div>
 
-    <div id="chat-input" class="bg-gray-800 p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
+    <div id="chat-input" class="bg-[#121212] p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
         <textarea id="message-input"
-                  class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
+                  class="flex-1 resize-none bg-[#2C2C2E] text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
                   style="max-height:200px;"
                   rows="1"
                   placeholder="Escribe tu mensaje..."></textarea>
         <button id="send-button"
-                class="bg-white text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
+                class="bg-[#FAFAFA] text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transform rotate-45" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
             </svg>

--- a/main.js
+++ b/main.js
@@ -52,9 +52,9 @@ function renderChatList() {
     chatListUI.innerHTML = '';
     for (const chat of chatList) {
         const li = document.createElement('li');
-        li.className = 'flex items-center justify-between bg-gray-800 px-3 py-2 rounded';
+        li.className = 'flex items-center justify-between bg-[#121212] px-3 py-2 rounded';
         const openBtn = document.createElement('button');
-        openBtn.className = 'flex-1 text-left';
+        openBtn.className = 'flex-1 text-left text-[#FAFAFA]';
         openBtn.textContent = chat.title;
         openBtn.addEventListener('click', async () => {
             chatMessages.innerHTML = '';
@@ -75,8 +75,8 @@ function renderChatList() {
             overlay.classList.add('hidden');
         });
         const delBtn = document.createElement('button');
-        delBtn.textContent = '🗑';
-        delBtn.className = 'ml-2 text-red-500';
+        delBtn.innerHTML = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6v12a2 2 0 002 2h4a2 2 0 002-2V6"/><path d="M10 10v6M14 10v6"/><path d="M9 6V4h6v2"/></svg>';
+        delBtn.className = 'ml-2';
         delBtn.addEventListener('click', async (e) => {
             e.stopPropagation();
             await deleteChat(chat.id);


### PR DESCRIPTION
## Summary
- cambia el esquema de color a fondo #121212
- usa #FAFAFA para los botones y #2C2C2E para campos de texto
- reemplaza el emoji de eliminar por un ícono SVG
- agrega íconos SVG para nuevo chat y personalización

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_687b4315a5a4832695d17091ca03c5fb