### PR TITLE
UI tweaks with overlay fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         }
     </style>
 </head>
-<body class="bg-black text-gray-100 min-h-screen">
+<body class="bg-black text-gray-100 min-h-screen transition-colors duration-300">
     <div class="flex flex-col w-full h-screen chat-container overflow-hidden">
         <div class="flex justify-between p-4">
             <button id="menu-button" class="text-white focus:outline-none">
@@ -55,7 +55,7 @@
         </div>
 
         <div id="intro-screen" class="flex-1 flex flex-col items-center justify-center text-center p-4 hidden">
-            <h1 class="text-2xl font-bold mb-4">¿En qué puedo ayudarte?</h1>
+            <h1 class="text-2xl font-bold mb-4 drop-shadow-lg">¿En qué puedo ayudarte?</h1>
             <div id="suggestions" class="flex flex-col items-center gap-3 w-full"></div>
         </div>
 
@@ -67,17 +67,19 @@
     <div id="sidebar" class="fixed top-0 right-0 w-64 h-full bg-[#121212] text-white transform translate-x-full transition-transform flex flex-col z-20">
         <div class="p-4 border-b border-gray-700 space-y-4">
             <button id="sidebar-new-chat" class="flex items-center gap-2 w-full text-[#FAFAFA]">
-                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M3 4h7v14H3zM14 4h7v14h-7z" />
-                    <path d="M12 13l4-4 3 3-4 4z" />
-                </svg>
+                <img src="newchat.png" alt="Nuevo" class="w-5 h-5" />
                 <span>Nuevo chat</span>
             </button>
-            <button id="customization-button" class="flex items-center gap-2 w-full text-[#FAFAFA]">
-                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M4 20h4l9-9-4-4-9 9v4z" />
-                    <path d="M14 7l3 3" />
-                </svg>
+            <button id="customization-button" class="flex items-center gap-2 w-full text-[#FAFAFA] relative">
+                <span class="relative">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M4 20h4l9-9-4-4-9 9v4z" />
+                        <path d="M14 7l3 3" />
+                    </svg>
+                    <svg class="absolute -top-1 -right-1 w-3 h-3 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M9.049 2.927a1 1 0 011.902 0l1.286 3.946a1 1 0 00.95.69h4.15c.969 0 1.371 1.24.588 1.81l-3.357 2.438a1 1 0 00-.364 1.118l1.286 3.946c.3.921-.755 1.688-1.54 1.118L10 13.347l-3.357 2.438c-.784.57-1.838-.197-1.539-1.118l1.285-3.946a1 1 0 00-.364-1.118L2.669 9.373c-.783-.57-.38-1.81.588-1.81h4.15a1 1 0 00.95-.69l1.286-3.946z" />
+                    </svg>
+                </span>
                 <span>Personalización</span>
             </button>
         </div>
@@ -90,15 +92,15 @@
         <div class="bg-[#121212] text-gray-100 p-6 rounded-lg space-y-4 w-11/12 max-w-md">
             <label class="block text-sm">
                 ¿Cómo debería llamarte Gatito Sentimental?
-                <input id="custom-name" type="text" class="mt-1 w-full bg-[#2C2C2E] rounded p-2" />
+                <input id="custom-name" type="text" class="mt-1 w-full bg-gray-700 rounded p-2" />
             </label>
             <label class="block text-sm">
                 ¿Qué características debería tener Gatito Sentimental?
-                <textarea id="custom-traits" rows="2" class="mt-1 w-full bg-[#2C2C2E] rounded p-2"></textarea>
+                <textarea id="custom-traits" rows="2" class="mt-1 w-full bg-gray-700 rounded p-2"></textarea>
             </label>
             <label class="block text-sm">
                 ¿Hay algo más que Gatito Sentimental debería saber sobre ti?
-                <textarea id="custom-extra" rows="2" class="mt-1 w-full bg-[#2C2C2E] rounded p-2"></textarea>
+                <textarea id="custom-extra" rows="2" class="mt-1 w-full bg-gray-700 rounded p-2"></textarea>
             </label>
             <div class="flex justify-end space-x-2">
                 <button id="custom-cancel" class="px-4 py-2 bg-[#FAFAFA] rounded">Cancelar</button>
@@ -109,12 +111,12 @@
 
     <div id="chat-input" class="bg-[#121212] p-4 flex items-center border-t border-gray-700 fixed bottom-0 left-0 w-full">
         <textarea id="message-input"
-                  class="flex-1 resize-none bg-[#2C2C2E] text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
+                  class="flex-1 resize-none bg-gray-700 text-gray-100 rounded-full py-2 px-4 mr-3 focus:outline-none focus:ring-2 focus:ring-gray-500 placeholder-gray-400"
                   style="max-height:200px;"
                   rows="1"
                   placeholder="Escribe tu mensaje..."></textarea>
         <button id="send-button"
-                class="bg-[#FAFAFA] text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
+                class="bg-white text-black rounded-full p-3 transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-500">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transform rotate-45" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
             </svg>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { chatMessages, messageInput, sendButton, menuButton, sidebar, sidebarNewChat, customizationButton, customizationModal, customNameInput, customTraitsInput, customExtraInput, customSaveButton, customCancelButton, chatList as chatListUI, introScreen, suggestionsContainer, overlay, addMessageToUI, showMessageMenu } from './ui.js';
+import { chatMessages, messageInput, sendButton, menuButton, sidebar, sidebarNewChat, customizationButton, customizationModal, customNameInput, customTraitsInput, customExtraInput, customSaveButton, customCancelButton, chatList as chatListUI, introScreen, suggestionsContainer, overlay, addMessageToUI, showMessageMenu, showOverlay, hideOverlay } from './ui.js';
 import { history, chatList, loadHistory, loadChatList, createNewChat, deleteChat, updateCurrentChatTitle, loadCustomization, saveCustomization, personalization, refreshSystemMessage } from './history.js';
 import { loadMemory } from './memory.js';
 import { sendMessage, regenerateResponse } from './chat.js';
@@ -27,7 +27,7 @@ function populateSuggestions() {
     for (const text of shuffled) {
         const btn = document.createElement('button');
         btn.textContent = text;
-        btn.className = 'bg-black text-gray-100 px-4 py-2 rounded-full shadow hover:bg-gray-700 transition w-full max-w-xs';
+        btn.className = 'bg-gray-700 text-gray-100 px-4 py-2 rounded-full shadow-lg hover:bg-gray-600 transition w-full max-w-xs';
         btn.addEventListener('click', () => {
             messageInput.value = text;
             hideIntro();
@@ -72,7 +72,7 @@ function renderChatList() {
             }
             hideIntro();
             sidebar.classList.add('translate-x-full');
-            overlay.classList.add('hidden');
+            hideOverlay();
         });
         const delBtn = document.createElement('button');
         delBtn.innerHTML = '<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6v12a2 2 0 002 2h4a2 2 0 002-2V6"/><path d="M10 10v6M14 10v6"/><path d="M9 6V4h6v2"/></svg>';
@@ -115,7 +115,11 @@ resizeInput();
 
 menuButton.addEventListener('click', () => {
     const isOpen = !sidebar.classList.toggle('translate-x-full');
-    overlay.classList.toggle('hidden', !isOpen);
+    if (isOpen) {
+        showOverlay();
+    } else {
+        hideOverlay();
+    }
 });
 
 overlay.addEventListener('click', () => {
@@ -123,7 +127,7 @@ overlay.addEventListener('click', () => {
     const menu = document.getElementById('message-menu');
     if (menu) menu.remove();
     customizationModal.classList.add('hidden');
-    overlay.classList.add('hidden');
+    hideOverlay();
 });
 
 sidebarNewChat.addEventListener('click', async () => {
@@ -132,7 +136,7 @@ sidebarNewChat.addEventListener('click', async () => {
     renderChatList();
     showIntro();
     sidebar.classList.add('translate-x-full');
-    overlay.classList.add('hidden');
+    hideOverlay();
 });
 
 customizationButton.addEventListener('click', async () => {
@@ -142,12 +146,12 @@ customizationButton.addEventListener('click', async () => {
     customExtraInput.value = personalization.extra || '';
     customizationModal.classList.remove('hidden');
     sidebar.classList.add('translate-x-full');
-    overlay.classList.remove('hidden');
+    showOverlay();
 });
 
 customCancelButton.addEventListener('click', () => {
     customizationModal.classList.add('hidden');
-    overlay.classList.add('hidden');
+    hideOverlay();
 });
 
 customSaveButton.addEventListener('click', async () => {
@@ -157,7 +161,7 @@ customSaveButton.addEventListener('click', async () => {
         extra: customExtraInput.value.trim()
     });
     customizationModal.classList.add('hidden');
-    overlay.classList.add('hidden');
+    hideOverlay();
 });
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/ui.js
+++ b/ui.js
@@ -16,6 +16,16 @@ export const introScreen = document.getElementById('intro-screen');
 export const suggestionsContainer = document.getElementById('suggestions');
 export const overlay = document.getElementById('overlay');
 
+export function showOverlay() {
+    overlay.classList.remove('hidden');
+    document.body.classList.add('bg-gray-700');
+}
+
+export function hideOverlay() {
+    overlay.classList.add('hidden');
+    document.body.classList.remove('bg-gray-700');
+}
+
 let openMenuBubble = null;
 
 export function addMessageToUI(text, sender = 'user') {
@@ -58,7 +68,7 @@ export function showMessageMenu(event, sender, bubble) {
     const existing = document.getElementById('message-menu');
     if (existing) {
         existing.remove();
-        overlay.classList.add('hidden');
+        hideOverlay();
         if (openMenuBubble === bubble) {
             openMenuBubble = null;
             return;
@@ -70,7 +80,7 @@ export function showMessageMenu(event, sender, bubble) {
     const menu = document.createElement('div');
     menu.id = 'message-menu';
     menu.className = 'fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-gray-700 text-white rounded shadow-lg p-4 text-sm space-y-2 z-30';
-    overlay.classList.remove('hidden');
+    showOverlay();
 
     const copyBtn = document.createElement('button');
     copyBtn.textContent = 'Copiar';
@@ -109,7 +119,7 @@ export function showMessageMenu(event, sender, bubble) {
     const closeMenu = (e) => {
         if (!menu.contains(e.target)) {
             menu.remove();
-            overlay.classList.add('hidden');
+            hideOverlay();
             openMenuBubble = null;
             document.removeEventListener('click', closeMenu);
         }


### PR DESCRIPTION
## Summary
- add overlay helpers to toggle grey background
- swap the new chat icon
- highlight "Personalización" button with a star
- soften intro heading and suggestion buttons
- grey-out input boxes and make send button white

## Testing
- `node -v`
- `node -e "import('./main.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687b4a0423a88326a6f90af76a3945b1