### PR TITLE
Actualiza flujo de chats y estética

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,7 @@
 import { loginButton } from './ui.js';
 
 export async function updateLoginState() {
+    if (!loginButton) return;
     try {
         const possibleFn = puter?.auth?.user;
         const user = typeof possibleFn === 'function' ? await possibleFn() : possibleFn;

--- a/chat.js
+++ b/chat.js
@@ -1,5 +1,5 @@
 import { chatMessages, messageInput, sendButton, introScreen, showMessageMenu, addMessageToUI } from './ui.js';
-import { history, saveHistory, updateCurrentChatTitle, chatList, refreshSystemMessage } from './history.js';
+import { history, saveHistory, updateCurrentChatTitle, chatList, refreshSystemMessage, ensureChatEntry } from './history.js';
 import { updateMemoryFromMessage, saveMemory } from './memory.js';
 
 export async function sendMessage(forcedText) {
@@ -17,6 +17,7 @@ export async function sendMessage(forcedText) {
     }
 
     history.push({ role: 'user', content: userMessage });
+    await ensureChatEntry(userMessage.substring(0, 30));
     await saveHistory();
     const memUpdated = updateMemoryFromMessage(userMessage);
     if (memUpdated) {
@@ -24,7 +25,8 @@ export async function sendMessage(forcedText) {
         refreshSystemMessage();
         await saveHistory();
     }
-    if (chatList.length > 0 && chatList[0].title === 'Nuevo chat') {
+    const firstChat = chatList.find(c => c.id === currentChatId);
+    if (firstChat && firstChat.title === 'Nuevo chat') {
         updateCurrentChatTitle(userMessage.substring(0, 30));
     }
 
@@ -58,8 +60,8 @@ export async function sendMessage(forcedText) {
                     img.src = 'foto_perfil.png';
                     img.alt = 'perfil';
                     img.className = 'w-8 h-8 rounded-full absolute';
-                    img.style.left = '-6px';
-                    img.style.top = '-6px';
+                    img.style.left = '-2px';
+                    img.style.top = '-2px';
                     botMessageDiv.appendChild(img);
                     textContainer = document.createElement('div');
                     botMessageDiv.appendChild(textContainer);

--- a/history.js
+++ b/history.js
@@ -1,6 +1,7 @@
 export let history = [];
 export let chatList = [];
 export let currentChatId = null;
+export let pendingChat = false;
 export let personalization = { name: '', traits: '', extra: '' };
 import { userMemory } from './memory.js';
 let systemMessage = buildSystemMessage();
@@ -78,10 +79,16 @@ export async function createNewChat() {
     currentChatId = id;
     refreshSystemMessage();
     history = [systemMessage];
-    chatList.unshift({ id, title: 'Nuevo chat' });
-    await saveChatList();
-    await saveHistory();
+    pendingChat = true;
     return id;
+}
+
+export async function ensureChatEntry(title) {
+    if (pendingChat) {
+        chatList.unshift({ id: currentChatId, title });
+        pendingChat = false;
+        await saveChatList();
+    }
 }
 
 export async function deleteChat(id) {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
             </button>
-            <button id="login-button" class="text-white focus:outline-none">Entrar</button>
         </div>
 
         <div id="intro-screen" class="flex-1 flex flex-col items-center justify-center text-center p-4 hidden">
@@ -73,16 +72,11 @@
                 </svg>
                 <span>Nuevo chat</span>
             </button>
-            <button id="customization-button" class="flex items-center gap-2 w-full text-[#FAFAFA] relative">
-                <span class="relative">
-                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M12 15.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z" />
-                        <path d="M19.4 15a1.65 1.65 0 00.33 1.82 2 2 0 01-2.82 2.82 1.65 1.65 0 00-1.82.33 1.65 1.65 0 00-.5 1.71 2 2 0 01-3.6 0 1.65 1.65 0 00-.5-1.71 1.65 1.65 0 00-1.82-.33 2 2 0 01-2.82-2.82 1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.71-.5 2 2 0 010-3.6 1.65 1.65 0 001.71-.5 1.65 1.65 0 00.33-1.82 2 2 0 012.82-2.82 1.65 1.65 0 001.82.33 1.65 1.65 0 00.5-1.71 2 2 0 013.6 0 1.65 1.65 0 00.5 1.71 1.65 1.65 0 001.82.33 2 2 0 012.82 2.82 1.65 1.65 0 00-.33 1.82 1.65 1.65 0 001.71.5 2 2 0 010 3.6 1.65 1.65 0 00-1.71.5z" />
-                    </svg>
-                    <svg class="absolute -top-1 -right-1 w-3 h-3 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M9.049 2.927a1 1 0 011.902 0l1.286 3.946a1 1 0 00.95.69h4.15c.969 0 1.371 1.24.588 1.81l-3.357 2.438a1 1 0 00-.364 1.118l1.286 3.946c.3.921-.755 1.688-1.54 1.118L10 13.347l-3.357 2.438c-.784.57-1.838-.197-1.539-1.118l1.285-3.946a1 1 0 00-.364-1.118L2.669 9.373c-.783-.57-.38-1.81.588-1.81h4.15a1 1 0 00.95-.69l1.286-3.946z" />
-                    </svg>
-                </span>
+            <button id="customization-button" class="flex items-center gap-2 w-full text-[#FAFAFA]">
+                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="#FAFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.325 4.317c.426-1.756 3.24-1.756 3.667 0a1.724 1.724 0 002.506 1.066c1.64-.946 3.433.847 2.487 2.488a1.724 1.724 0 001.065 2.505c1.757.426 1.757 3.24 0 3.666a1.724 1.724 0 00-1.066 2.506c.946 1.64-.847 3.433-2.487 2.487a1.724 1.724 0 00-2.505 1.066c-.427 1.757-3.241 1.757-3.667 0a1.724 1.724 0 00-2.506-1.066c-1.64.946-3.433-.847-2.487-2.487a1.724 1.724 0 00-1.066-2.505c-1.756-.427-1.756-3.241 0-3.667a1.724 1.724 0 001.066-2.505C4.893 6.23 6.686 4.437 8.326 5.383a1.724 1.724 0 002.505-1.066z" />
+                    <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
                 <span>Personalización</span>
             </button>
         </div>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { chatMessages, messageInput, sendButton, menuButton, loginButton, sidebar, sidebarNewChat, customizationButton, customizationModal, customNameInput, customTraitsInput, customExtraInput, customSaveButton, customCancelButton, chatList as chatListUI, introScreen, suggestionsContainer, overlay, addMessageToUI, showMessageMenu, showOverlay, hideOverlay } from './ui.js';
+import { chatMessages, messageInput, sendButton, menuButton, sidebar, sidebarNewChat, customizationButton, customizationModal, customNameInput, customTraitsInput, customExtraInput, customSaveButton, customCancelButton, chatList as chatListUI, introScreen, suggestionsContainer, overlay, addMessageToUI, showMessageMenu, showOverlay, hideOverlay } from './ui.js';
 import { history, chatList, loadHistory, loadChatList, createNewChat, deleteChat, updateCurrentChatTitle, loadCustomization, saveCustomization, personalization, refreshSystemMessage } from './history.js';
 import { loadMemory } from './memory.js';
 import { sendMessage, regenerateResponse } from './chat.js';
@@ -171,10 +171,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadMemory();
     refreshSystemMessage();
     await loadChatList();
-    if (chatList.length === 0) {
+    if (chatList.length > 0) {
+        await loadHistory(chatList[0].id);
+    } else {
         await createNewChat();
     }
-    await loadHistory(chatList[0].id);
     renderChatList();
     if (history.length > 1) {
         hideIntro();

--- a/ui.js
+++ b/ui.js
@@ -47,8 +47,8 @@ export function addMessageToUI(text, sender = 'user') {
         img.src = 'foto_perfil.png';
         img.alt = 'perfil';
         img.className = 'w-8 h-8 rounded-full absolute';
-        img.style.left = '-6px';
-        img.style.top = '-6px';
+        img.style.left = '-2px';
+        img.style.top = '-2px';
         bubble.appendChild(img);
         const content = document.createElement('div');
         content.innerHTML = marked.parse(text);


### PR DESCRIPTION
## Summary
- create chat entry only after first message
- tweak intro load logic for pending chats
- adjust profile avatar position
- swap customization icon for a gear
- remove login button and guard login update

## Testing
- `node -c chat.js`
- `node -c history.js`
- `node -c main.js`
- `node -c ui.js`
- `node -c auth.js`

------
https://chatgpt.com/codex/tasks/task_e_687c73fb0d1483268ac558d680f584b6